### PR TITLE
Add fix to serialize inner model

### DIFF
--- a/faust_avro_serializer/avro_serializer.py
+++ b/faust_avro_serializer/avro_serializer.py
@@ -1,4 +1,5 @@
 import typing
+from collections.abc import Mapping, Sequence
 
 import faust
 from schema_registry.client import SchemaRegistryClient
@@ -27,8 +28,8 @@ class FaustAvroSerializer(MessageSerializer, faust.Codec):
 
     @staticmethod
     def _clean_item(item: typing.Any) -> typing.Any:
-        if isinstance(item, Record):
-            return Serializer._clean_item(item.to_representation())
+        if isinstance(item, faust.Record):
+            return FaustAvroSerializer._clean_item(item.to_representation())
         elif isinstance(item, str):
             # str is also a sequence, need to make sure we don't iterate over it.
             return item

--- a/faust_avro_serializer/avro_serializer.py
+++ b/faust_avro_serializer/avro_serializer.py
@@ -28,12 +28,12 @@ class FaustAvroSerializer(MessageSerializer, faust.Codec):
     @staticmethod
     def clean_payload(payload: typing.Dict[str, typing.Any]) -> typing.Dict[str, typing.Any]:
         """
-        Try to clean payload retrieve by faust.Record.to_representation.
+        Try to clean payload retrieved by faust.Record.to_representation.
         All values inside payload should be native types and not faust.Record
         On Faust versions <=1.9.0 Record.to_representation always returns a dict with native types
-        as a values which are compatible with fastavro.
-        On Faust 1.10.0 <= versions Record.to_representation always returns a dic but values
-        can also be faust.Record, so fastavro is incapable of serialize them
+        as a value which are compatible with fastavro.
+        On Faust 1.10.0 <= versions Record.to_representation always returns a dict but values
+        can also be faust.Record, so fastavro is incapable to serialize them
         Args:
             payload (dict): Payload to clean
         Returns:

--- a/tests/clean_payload_test.py
+++ b/tests/clean_payload_test.py
@@ -1,0 +1,58 @@
+import typing
+
+from faust import Record
+
+from faust_avro_serializer import FaustAvroSerializer
+
+
+class DummyRecord(Record):
+    item: typing.Any
+
+
+def test_simple_record():
+    result = {"__faust": {"ns": "tests.clean_payload_test.DummyRecord"}, "item": "test"}
+
+    dummy = DummyRecord("test")
+    assert result == FaustAvroSerializer.clean_payload(dummy)
+
+
+def test_nested_record():
+    result = {
+        "__faust": {"ns": "tests.clean_payload_test.DummyRecord"},
+        "item": {"__faust": {"ns": "tests.clean_payload_test.DummyRecord"}, "item": "test"},
+    }
+
+    dummy = DummyRecord(DummyRecord("test"))
+    assert result == FaustAvroSerializer.clean_payload(dummy)
+
+
+def test_list_of_records():
+    result = {
+        "__faust": {"ns": "tests.clean_payload_test.DummyRecord"},
+        "item": [
+            {"__faust": {"ns": "tests.clean_payload_test.DummyRecord"}, "item": "test"},
+            {"__faust": {"ns": "tests.clean_payload_test.DummyRecord"}, "item": "test"},
+        ],
+    }
+
+    dummy = DummyRecord([DummyRecord("test"), DummyRecord("test")])
+    assert result == FaustAvroSerializer.clean_payload(dummy)
+
+
+def test_map_of_records():
+    result = {
+        "__faust": {"ns": "tests.clean_payload_test.DummyRecord"},
+        "item": {
+            "key1": {
+                "__faust": {"ns": "tests.clean_payload_test.DummyRecord"},
+                "item": "test",
+            },
+            "key2": {
+                "__faust": {"ns": "tests.clean_payload_test.DummyRecord"},
+                "item": "test",
+            },
+        },
+    }
+
+    dummy = DummyRecord({"key1": DummyRecord("test"), "key2": DummyRecord("test")})
+    assert result == FaustAvroSerializer.clean_payload(dummy)


### PR DESCRIPTION
Hello!

Nice project, I just start to experiment with it, might I suggest this fix?

This is to be able to serialize a model of this form:

```
class Other(Record):
    field: str

class Model(Record):
    other_record: Other
```

This code used for this fix is from here:

https://github.com/marcosschroh/python-schema-registry-client/blob/f18d0929f45bd5e096150db614f3bbec28346557/schema_registry/serializers/faust_serializer.py#L50