### PR TITLE
Update python-schema-registry-client dependency to 2.5.0

### DIFF
--- a/faust_avro_serializer/avro_serializer.py
+++ b/faust_avro_serializer/avro_serializer.py
@@ -3,7 +3,7 @@ from collections.abc import Mapping, Sequence
 
 import faust
 from schema_registry.client import SchemaRegistryClient
-from schema_registry.serializers import MessageSerializer
+from schema_registry.serializers import AvroMessageSerializer
 from faust.models.base import registry
 from schema_registry.client.schema import AvroSchema
 
@@ -12,7 +12,7 @@ class MissingSchemaException(Exception):
     pass
 
 
-class FaustAvroSerializer(MessageSerializer, faust.Codec):
+class FaustAvroSerializer(AvroMessageSerializer, faust.Codec):
     _mapping_key = {
         True: "key",
         False: "value"
@@ -23,7 +23,7 @@ class FaustAvroSerializer(MessageSerializer, faust.Codec):
         self.schema_subject = subject
         self.is_key = is_key
 
-        MessageSerializer.__init__(self, client)
+        AvroMessageSerializer.__init__(self, client)
         faust.Codec.__init__(self, client=client, subject=subject, is_key=is_key, **kwargs)
 
     def _loads(self, s: bytes) -> typing.Optional[typing.Dict]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ home-page = "https://github.com/bakdata/faust-avro-serializer"
 description-file="README.md"
 requires-python = ">=3.6"
 requires = [
-    "python-schema-registry-client==1.8.2",
+    "python-schema-registry-client==2.5.0",
     "faust-streaming",
     "bump2version"
 ]


### PR DESCRIPTION
Hello !

This Pull Request updates the python-schema-registry-client dependency to 2.5.0.

This update impact projects that uses more recent version of httpx (used by python-schema-registry-client) and collides with other libraries like FastAPI